### PR TITLE
Use local_vec::LocalVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ description = "vector optimized for small buffers"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+local_vec = "~0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "small_vec"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Jorge Rinaldi <jrg.rinaldi@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A *dynamic array* or vector supporting *small buffer optimization*.
 
 `SmallVec<T, N>` is, in essence, just an `enum` with two variants:
 
-- `Local`: a buffer allocated locally inside the `SmallVec` itself.
-- `Remote`: a `Vec<T>`, i.e., a remote buffer allocated on the heap.
+- `LocalBuf`: a buffer allocated locally inside the `SmallVec` itself.
+- `RemoteBuf`: a `Vec<T>`, i.e., a remote buffer allocated on the heap.
 
 
-The capacity of the local buffer is specified at compile time as a constant generic argument to `SmallVec`.
+The capacity of the local buffer is specified at compile time as a constant generic argument to `SmallVec` thanks to *const generics*.
 
 
 

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -1,17 +1,8 @@
 use crate::SmallVec;
 
+// TODO not needed anymore
 impl<T, const N: usize> Drop for SmallVec<T, N> {
-    fn drop(&mut self) {
-        match self {
-            Self::Local(_, _) => {
-                while let Some(val) = self.pop() {
-                    // superfluous
-                    std::mem::drop(val);
-                }
-            }
-            Self::Remote(_) => (),
-        }
-    }
+    fn drop(&mut self) {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Use the local_vec::LocalVec struct instead of own Local([T; N], size /* len */) variant for the local buffer.